### PR TITLE
changed docker networking to support linux (and mac)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ models/embedding_model/*
 ./models/**
 ./**/**/.DS_Store
 ./**/**/*.pyc
+.qodo

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     ports:
       - "6379:6379"
     command: ["redis-server", "--appendonly", "yes"]
-    network_mode: bridge
+    network_mode: host
     volumes:
       - redis_data:/data
 
@@ -16,6 +16,7 @@ services:
       context: .
       dockerfile: dockerfiles/langchain_bot/Dockerfile
     container_name: langchain_bot
+    network_mode: host
     depends_on:
       - redis
     environment:

--- a/sample.env
+++ b/sample.env
@@ -1,9 +1,9 @@
 OPENAI_API_KEY=xxx
 DB_URL=xxx
-REDIS_URL=redis://host.docker.internal:6379
+REDIS_URL=redis://localhost:6379
 REDIS_TOKEN=1233
 TOKENIZERS_PARALLELISM=true
-OLLAMA_HOST=http://host.docker.internal:11434
+OLLAMA_HOST=http://localhost:11434
 LLM_PROVIDER=gemini
 GEMINI_API_KEY=xxx
 HF_TOKEN=XXX


### PR DESCRIPTION
used host networking instead of docker internal networking. WARNING: this may case conflicts if the mac is using the same port. Also added to .gitignore to get around qodo (visual studio plugin). 